### PR TITLE
Added extra fields to be used for from_dictionary

### DIFF
--- a/message_media_messages/models/message.py
+++ b/message_media_messages/models/message.py
@@ -112,10 +112,14 @@ class Message(object):
             return None
 
         # Extract variables from the dictionary
-        content = dictionary.get('content')
-        destination_number = dictionary.get('destination_number')
+        attributes = ['callback_url', 'content', 'destination_number', 'delivery_report', 'format', 'message_expiry_timestamp',
+         'metadata', 'scheduled', 'source_number', 'source_number_type', 'message_id', 'status', 'media', 'subject']
+
+        msg_dictionary = dict()
+        for key, value in  dictionary.items():
+            if key in attributes:
+                msg_dictionary[key] = value
 
 
         # Return an object of this model
-        return cls(content,
-                   destination_number)
+        return cls(**msg_dictionary)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from codecs import open
 from os import path
 here = path.abspath(path.dirname(__file__))
 
-with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
When using SDK I noticed that after I send a message the `message_id` won't be set for the response message object only for content and destination_number.

I discovered that the message `from_dictionary` function only sets the values of content and destination_number, which was the reason for the bug.