### PR TITLE
Bugfix: Fix SyntaxWarning when comparing a literal with 'is' instead of '=='

### DIFF
--- a/message_media_messages/api_helper.py
+++ b/message_media_messages/api_helper.py
@@ -124,11 +124,11 @@ class APIHelper(object):
             serializable_types = (str, int, float, bool, datetime.date, APIHelper.CustomDate)
 
         if isinstance(array[0], serializable_types):
-            if formatting is "unindexed":
+            if formatting == "unindexed":
                 tuples += [("{0}[]".format(key), element) for element in array]
-            elif formatting is "indexed":
+            elif formatting == "indexed":
                 tuples += [("{0}[{1}]".format(key, index), element) for index, element in enumerate(array)]
-            elif formatting is "plain":
+            elif formatting == "plain":
                 tuples += [(key, element) for element in array]
             else:
                 raise ValueError("Invalid format provided.")
@@ -199,13 +199,13 @@ class APIHelper(object):
             if value is not None:
                 if isinstance(value, list):
                     value = [element for element in value if element]
-                    if array_serialization is "csv":
+                    if array_serialization == "csv":
                         url += "{0}{1}={2}".format(seperator, key,
                             ",".join(quote(str(x), safe='') for x in value))
-                    elif array_serialization is "psv":
+                    elif array_serialization == "psv":
                         url += "{0}{1}={2}".format(seperator, key,
                             "|".join(quote(str(x), safe='') for x in value))
-                    elif array_serialization is "tsv":
+                    elif array_serialization == "tsv":
                         url += "{0}{1}={2}".format(seperator, key,
                             "\t".join(quote(str(x), safe='') for x in value))
                     else:


### PR DESCRIPTION
Hi maintainers!

This is a simple change to fix the `SyntaxWarning` raised by pytest when using this library.

Example:

```
.../site-packages/message_media_messages/api_helper.py:127: SyntaxWarning: "is" with a literal. Did you mean "=="?
    if formatting is "unindexed":
```

Cheers!