### PR TITLE
Upgrade urllib3 to >=2.0, update dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-requests==2.28.2
+requests>=2.31.0
 jsonpickle==3.0.1
 cachecontrol==0.12.11
 python-dateutil==2.8.2
 responses~=0.22.0
-urllib3~=1.26.14
+urllib3>=2.0.0
 setuptools==67.2.0

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='messagemedia-messages-sdk',
-    version='2.1.2',
+    version='2.1.4',
     description='The MessageMedia Messages API provides a number of endpoints for building powerful two-way messaging applications.',
     long_description_content_type="text/markdown",
     long_description=long_description,
@@ -17,12 +17,12 @@ setup(
     url='https://developers.messagemedia.com',
     packages=find_packages(),
     install_requires=[
-        'requests>=2.28.2, <3.0',
+        'requests>=2.31.0, <3.0',
         'jsonpickle>=3.0.1, <4.0',
         'cachecontrol>=0.12.11, <1.0',
         'python-dateutil>=2.8.2, <3.0',
         'responses>=0.22.0, <1.0',
-        'urllib3>=1.26.14, <2.0',
+        'urllib3>=2.0',
         'setuptools>=67.2.0, <68'
     ]
 )


### PR DESCRIPTION
This pull request proposes a version bump to 3.0.0 due to breaking changes introduced by dependency updates.

Changes
Updated urllib3 to >=2.0

Updated requests to >=2.31.0, required for compatibility with urllib3 >=2.0

Continuing to use urllib3 versions below 2.0 is no longer sustainable, as many widely used libraries are now requiring urllib3 >=2.0. Maintaining compatibility with older versions introduces conflicts and limits integration with the broader Python ecosystem.